### PR TITLE
Dump command for backups/env sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 profiles/
+qtrix.dump

--- a/lib/qtrix/cli.rb
+++ b/lib/qtrix/cli.rb
@@ -54,6 +54,9 @@ Where available sub-commands are:
                 configuration set.
   overrides:    Perform operations on overrides within a
                 configuration set.
+  dump:         Dump all configuration from redis into
+                an executable file capable of recreating
+                the qtrix environment.
 
 For more information about the subcommands, try:
 
@@ -65,11 +68,13 @@ For more information about the subcommands, try:
     require 'qtrix/cli/config_sets'
     require 'qtrix/cli/queues'
     require 'qtrix/cli/overrides'
+    require 'qtrix/cli/dump'
 
     @commands = {
       config_sets:      ConfigSets,
       overrides:        Overrides,
       queues:           Queues,
+      dump:             Dump,
       :"config-sets" => ConfigSets,
     }
 

--- a/lib/qtrix/cli/dump.rb
+++ b/lib/qtrix/cli/dump.rb
@@ -1,0 +1,88 @@
+module Qtrix
+  module CLI
+    class Dump < Base
+      banner <<-EOS
+
+Usage: bundle exec qtrix dump
+
+Dumps an executable script that will recreate all configuration
+sets within a redis instance backing qtrix.  Useful for backup
+purposes, or to maintain synchronization between environments
+(prod, staging, etc...).
+
+Options include:
+
+      EOS
+
+      option :file,
+        short:       '-f PATH',
+        long:        '--file PATH',
+        description: 'Specify the file path to dump to',
+        default:     './qtrix.dump'
+
+      option :host,
+        short:       '-h HOST',
+        description: 'The host where redis is located',
+        default:     'localhost'
+
+      option :port,
+        short:       '-p PORT',
+        description: 'The host which redis is listening on',
+        default:     6379
+
+      option :db,
+        short:       '-n DB',
+        description: 'The redis DB where the action should occur',
+        default:     0
+
+      def exec_behavior
+        File.open(config[:file], "w") do |file|
+          Qtrix.configuration_sets.each do |config_set|
+            file.write(config_set_dump(config_set))
+          end
+        end
+        FileUtils.chmod(0755, config[:file])
+        write("Dumped all config-sets to #{config[:file]}.")
+      end
+
+      private
+      def config_set_dump(name)
+        "".tap do |result|
+          unless name.to_sym == :default
+            result << create_config_set_cmd(name)
+          end
+          result << map_queues_cmd(name)
+          Qtrix.overrides(name).each do |override|
+            result << override_cmd(override, name)
+          end
+        end
+      end
+
+      def create_config_set_cmd(cs)
+        "#{command_start} config_sets --create #{cs} #{redis_options}\n"
+      end
+
+      def map_queues_cmd(cs)
+        weights = Qtrix.desired_distribution(cs).map{|q| "#{q.name}:#{q.weight}"}.join(",")
+        "#{command_start} queues -w #{weights} #{config_set(cs)} #{redis_options}\n"
+      end
+
+      def override_cmd(override, cs)
+        "#{command_start} overrides -a -q #{override.queues.join(',')} " +
+        "-w 1 #{config_set(cs)} #{redis_options}\n"
+      end
+
+      def command_start
+        "bundle exec qtrix"
+      end
+
+      def config_set(name)
+        "-c #{name}"
+      end
+
+      def redis_options
+        "-h #{config[:host]} -p #{config[:port]} -n #{config[:db]}"
+      end
+    end
+  end
+end

--- a/spec/qtrix/cli/dump_spec.rb
+++ b/spec/qtrix/cli/dump_spec.rb
@@ -1,0 +1,67 @@
+require 'fileutils'
+require 'tmpdir'
+require 'qtrix/cli/spec_helper'
+
+describe Qtrix::CLI::Dump do
+  include_context "cli commands"
+
+  let(:command) {Qtrix::CLI::Dump.new(stdout_stream, stderr_stream)}
+  let(:dump) {File.readlines("qtrix.dump")}
+
+  context "to specified file path" do
+    it "should write file to specified path" do
+      path = File.join(Dir.mktmpdir, 'test.dump')
+      command.parse_options "-f #{path}".split
+      command.exec
+      File.exists?(path).should == true
+    end
+  end
+
+  context "to default file path with default and night config sets" do
+    before(:each) do
+      Qtrix.map_queue_weights A: 10, B: 8
+      Qtrix.add_override [:Y,:Z], 2
+      Qtrix.create_configuration_set(:night)
+      Qtrix.map_queue_weights :night, C: 10, D: 5
+      Qtrix.add_override :night, [:I,:J], 2
+      command.parse_options
+      command.exec
+    end
+
+    after(:each) {FileUtils.rm('qtrix.dump')}
+
+    it "should create dump file containing command to create night config set" do
+      pattern = /bundle exec qtrix config_sets --create night -h localhost -p 6379 -n 0/
+      dump.grep(pattern).should_not be_empty
+    end
+
+    it "should create dump file that does not contain command to create default config set" do
+      pattern = /--create default/
+      dump.grep(pattern).should be_empty
+    end
+
+    it "should create dump file that contains command to map defaults queue weights" do
+      pattern = /bundle exec qtrix queues -w A:10.0,B:8.0 -c default -h localhost -p 6379 -n 0/
+      dump.grep(pattern).should_not be_empty
+    end
+
+    it "should create dump file that contains command to map night's queue weights" do
+      pattern = /bundle exec qtrix queues -w C:10.0,D:5.0 -c night -h localhost -p 6379 -n 0/
+      dump.grep(pattern).should_not be_empty
+    end
+
+    it "should create dump file that contains commands to add default's overrides" do
+      pattern = /bundle exec qtrix overrides -a -q Y,Z -w 1 -c default -h localhost -p 6379 -n 0/
+      dump.grep(pattern).size.should == 2
+    end
+
+    it "should create dump file that contains commands to add default's overrides" do
+      pattern = /bundle exec qtrix overrides -a -q I,J -w 1 -c night -h localhost -p 6379 -n 0/
+      dump.grep(pattern).size.should == 2
+    end
+
+    it "should create dump file that is executable" do
+      File.executable?("qtrix.dump").should == true
+    end
+  end
+end


### PR DESCRIPTION
qtrix dump will dump commands to recreate a qtrix environment
to an executable file.  All config sets, overrides, queue weights,
etc... will be included.

This is useful for backup or environment synchronization purposes.