### PR TITLE
Upgrade to redis namespace 1.2

### DIFF
--- a/lib/qtrix/queue.rb
+++ b/lib/qtrix/queue.rb
@@ -18,8 +18,7 @@ module Qtrix
 
       def all_queues(namespace=:current)
         raw = redis(namespace).zrevrange(REDIS_KEY, 0, -1, withscores: true)
-        result = []
-        raw.each_slice(2) do |tuple|
+        result = raw.each_with_object([]) do |tuple, result|
           result << self.new(namespace, tuple[0], tuple[1].to_f)
         end
         if result.empty?

--- a/qtrix.gemspec
+++ b/qtrix.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_dependency "redis-namespace", "~> 1.0.2"
+  gem.add_dependency "redis-namespace", "~> 1.2"
   gem.add_dependency "mixlib-cli", "1.3.0"
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency "rspec-core", "2.11.0"


### PR DESCRIPTION
Allows use with newer versions of redis required by resque 1.4.1.

The only change required was that we no longer need to use each_slice with sorted sets.  Redis namespace now returns an array of tuples including the element and its priority/score.
