### PR TITLE
Various code cleanup

### DIFF
--- a/lib/qtrix.rb
+++ b/lib/qtrix.rb
@@ -123,10 +123,10 @@ module Qtrix
   # Retrieves lists of queues as appropriate to the overall system balance
   # for the number of workers specified for the given +hostname+.
 
-  def self.fetch_queues(hostname, workers)
+  def self.fetch_queues(hostname, workers, opts={})
     HostManager.ping(hostname)
     clear_matrix_if_any_hosts_offline
-    with_lock timeout: 5, on_timeout: last_result do
+    with_lock timeout: opts.fetch(:timeout, 5), on_timeout: last_result do
       debug("fetching #{workers} queue lists for #{hostname}")
       overrides_queues = Qtrix::Override.overrides_for(hostname, workers)
       debug("overrides for #{hostname}: #{overrides_queues}")

--- a/lib/qtrix.rb
+++ b/lib/qtrix.rb
@@ -42,7 +42,7 @@ module Qtrix
   # Returns the public operations of the facade.  Useful when tinkering
   # in a REPL.
   def self.operations
-    self.public_methods
+    self.public_methods - Module.public_methods
   end
 
   ##

--- a/lib/qtrix.rb
+++ b/lib/qtrix.rb
@@ -48,7 +48,7 @@ module Qtrix
   ##
   # Returns a list of objects that define the desired distribution
   # of workers.  Each element will contain the queue name, weight, and
-  # resource_percentage (weight / total weight of all queues).
+  # relative_weight (weight / total weight of all queues).
 
   def self.desired_distribution
     Queue.all_queues

--- a/lib/qtrix/matrix/queue_prioritizer.rb
+++ b/lib/qtrix/matrix/queue_prioritizer.rb
@@ -51,11 +51,11 @@ module Qtrix
       end
 
       def normal_priority_for(queue)
-        queue.resource_percentage / (1 + sum_of(entries_for(queue)))
+        queue.relative_weight / (1 + sum_of(entries_for(queue)))
       end
 
       def starting_priority_for(queue)
-        queue.resource_percentage * 10000
+        queue.relative_weight * 10000
       end
 
       def sum_of(entries)

--- a/lib/qtrix/matrix/queue_prioritizer.rb
+++ b/lib/qtrix/matrix/queue_prioritizer.rb
@@ -29,7 +29,7 @@ module Qtrix
         dist.map{|queue| [queue, current_priority_of(queue)]}
       end
 
-      def by_priority_of_tuple(context={})
+      def by_priority_of_tuple
         lambda {|i, j| j[1] <=> i[1]}
       end
 

--- a/lib/qtrix/matrix/row_builder.rb
+++ b/lib/qtrix/matrix/row_builder.rb
@@ -50,7 +50,7 @@ module Qtrix
       def build_entry(row, queue, entry_val)
         entry = Entry.new(
           queue.name,
-          queue.resource_percentage,
+          queue.relative_weight,
           entry_val
         )
         all_entries << entry

--- a/lib/qtrix/queue.rb
+++ b/lib/qtrix/queue.rb
@@ -74,8 +74,8 @@ module Qtrix
       name.hash - weight.hash
     end
 
-    def resource_percentage
-      @resource_percentage ||= weight.to_f / self.class.total_weight
+    def relative_weight
+      @relative_weight ||= weight.to_f / self.class.total_weight
     end
 
     def weight

--- a/lib/qtrix/queue.rb
+++ b/lib/qtrix/queue.rb
@@ -58,10 +58,6 @@ module Qtrix
         raise "weight of 0 or less" if weight <= 0
         raise "weight cannot be > 999" if weight > 999
       end
-
-      def high_low
-        lambda{|i,j| j.weight <=> i.weight}
-      end
     end
     attr_reader :name
 

--- a/lib/qtrix/queue.rb
+++ b/lib/qtrix/queue.rb
@@ -17,16 +17,22 @@ module Qtrix
 
 
       def all_queues
+        # load queues as an array of arrays, where each inner array is a
+        # name and weight: [[:queueA, 5.0],[:queueB, 3.0]]
         raw = Persistence.redis.zrevrange(REDIS_KEY, 0, -1, withscores: true)
-        result = raw.each_with_object([]) do |tuple, result|
-          result << self.new(tuple[0], tuple[1].to_f)
-        end
-        if result.empty?
+        total_weight = raw.inject(0){|sum,tuple| sum + tuple[1]}
+
+        # build immutable Queue instances
+        queues = raw.map{|name, weight|
+          relative_weight = weight.to_f / total_weight
+          self.new(name, weight, relative_weight)
+        }
+        if queues.empty?
           msg = "No queue distribution defined"
           warn(msg)
           raise Qtrix::ConfigurationError, msg
         end
-        result
+        queues
       end
 
       def to_map
@@ -38,10 +44,6 @@ module Qtrix
 
       def count
         Persistence.redis.zcard(REDIS_KEY)
-      end
-
-      def total_weight
-        all_queues.inject(0) {|memo, queue| memo += queue.weight}
       end
 
       def clear!
@@ -59,11 +61,13 @@ module Qtrix
         raise "weight cannot be > 999" if weight > 999
       end
     end
-    attr_reader :name
 
-    def initialize(name, weight)
+    attr_reader :name, :weight, :relative_weight
+
+    def initialize(name, weight, relative_weight)
       @name = name.to_sym
       @weight = weight.to_f
+      @relative_weight = relative_weight
     end
 
     def ==(other)
@@ -72,14 +76,6 @@ module Qtrix
 
     def hash
       name.hash - weight.hash
-    end
-
-    def relative_weight
-      @relative_weight ||= weight.to_f / self.class.total_weight
-    end
-
-    def weight
-      @weight ||= Persistence.redis.zscore(REDIS_KEY, name).to_f
     end
   end
 end

--- a/spec/qtrix/queue_spec.rb
+++ b/spec/qtrix/queue_spec.rb
@@ -14,7 +14,7 @@ describe Qtrix::Queue do
   let(:matrix) {Qtrix::Matrix}
 
   context "comparing two queues with the same name and weights" do
-    let(:other_queue) {Qtrix::Queue.new(:a, 2)}
+    let(:other_queue) {Qtrix::Queue.new(:a, 2, 5)}
     describe "#==" do
       it "should return true" do
         queue1.should == other_queue
@@ -29,7 +29,7 @@ describe Qtrix::Queue do
   end
 
   context "comparing two queues with the same name and different weights" do
-    let(:other_queue) {other_queue = Qtrix::Queue.new(:a, 3)}
+    let(:other_queue) {other_queue = Qtrix::Queue.new(:a, 3, 5)}
     describe "#==" do
       it "should return false" do
         queue1.should_not == other_queue
@@ -44,7 +44,7 @@ describe Qtrix::Queue do
   end
 
   context "comparing two queues with the same weight and different names" do
-    let(:other_queue) {other_queue = Qtrix::Queue.new(:b, 2)}
+    let(:other_queue) {other_queue = Qtrix::Queue.new(:b, 2, 5)}
     describe "#==" do
       it "should return false" do
         queue1.should_not == other_queue
@@ -132,12 +132,6 @@ describe Qtrix::Queue do
     describe "#count" do
       it "should be the number of queues mapped" do
         Qtrix::Queue.count.should == 3
-      end
-    end
-
-    describe "#total_weight" do
-      it "should contain the sum of all weights" do
-        Qtrix::Queue.total_weight == 6
       end
     end
 

--- a/spec/qtrix/queue_spec.rb
+++ b/spec/qtrix/queue_spec.rb
@@ -58,10 +58,10 @@ describe Qtrix::Queue do
     end
   end
 
-  describe "#resource_percentage" do
+  describe "#relative_weight" do
     it "should equal weight / total weight of all queues" do
-      queue1.resource_percentage.should == 0.4
-      queue2.resource_percentage.should == 0.6
+      queue1.relative_weight.should == 0.4
+      queue2.relative_weight.should == 0.6
     end
   end
 

--- a/spec/qtrix_spec.rb
+++ b/spec/qtrix_spec.rb
@@ -83,7 +83,7 @@ describe Qtrix do
         Qtrix.map_queue_weights Z: 1
         redis.set :lock, Qtrix::Persistence.redis_time + 15
 
-        result = Qtrix.fetch_queues('host1', 1)
+        result = Qtrix.fetch_queues('host1', 1, timeout: 0.5)
         result.should == [[:A, :B, :C, :D, :__orchestrated__]]
       end
 


### PR DESCRIPTION
Nothing should change outward behavior.

The biggest change is renaming `Queue#resource_percentage` to `Queue#relative_weight`, which better describes the value, and differentiates it from `Matrix::Entry#resource_percentage` which is based on a completely different calculation.

Also made `Queue` immutable - we now tell it its relative weight, instead of having it calculate the relative weight itself. It was awkward for an instance to need knowledge of all other instances to do an internal calculation.